### PR TITLE
Corrigindo o endereço da CPBR

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                     <h4>Campus Party 2014</h4>
                     <ul>
                       <li><b>Data:</b> 27/01 à 02/02/2014</li>
-                      <li><b>Local:</b> Germinadora | Rua Engenheiro José Sá Rocha, 173 Vila Mariana, São Paulo - SP
+                      <li><b>Local:</b> Anhembi Parque, São Paulo/SP. (Avenida Olavo Fontoura, 1.209)
                     </ul>
                     <p>Mais detalhes: <a href="http://www.campus-party.com.br/2014/index.html">site oficial da Campus Party</a></p>
                     <hr>


### PR DESCRIPTION
O endereço da campus foi corrigido. Estava como Germinadora.
