### PR TITLE
Removendo Eventos já ocorridos

### DIFF
--- a/javascripts/data/events.json
+++ b/javascripts/data/events.json
@@ -1,30 +1,6 @@
 {
     "events": [
         {
-            "titulo": "RSJS 2016",
-            "dataInicio": "2016-04-23",
-            "dataFim": "2016-04-23",
-            "local": "Senac - Auditório Master, prédio A",
-            "endereco": "Rua Cel. Genuíno, 130 - Porto Alegre, Rio Grande do Sul",
-            "localizacao": {
-                "latitude": -30.035229,
-                "longitude": -51.226507
-            },
-            "link": "http://rsjs.org/2016/"
-        },
-        {
-            "titulo": "JSday Campina Grande",
-            "dataInicio": "2016-04-23",
-            "dataFim": "2016-04-23",
-            "local": "UNIFACISA",
-            "endereco": "Av. Senador Argemiro de Figueiredo, 1901 - Itararé, Campina Grande",
-            "localizacao": {
-                "latitude": -7.2727621,
-                "longitude": -35.8881897
-            },
-            "link": "http://jsday.com.br/"
-        },
-        {
             "titulo": "TechParty - 2016",
             "dataInicio": "2016-04-25",
             "dataFim": "2016-04-29",


### PR DESCRIPTION
Retirado o evento RSJS 2016 e o JSday Campina Grande