### PR TITLE
Incluindo Prittier e atualizando versoes dos pacotes do npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ before_script:
 script:
   - htmlhint index.html
   - jshint javascripts/**/*.{js,json}
+  - prettier --write javascripts/**/*.{js,json}
   - csslint **/*.css
   - mocha javascripts/tests/*.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3362 @@
+{
+    "name": "saiadecasa",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@yarnpkg/lockfile": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+            "dev": true
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+            "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
+        },
+        "ajv": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "dev": true,
+            "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+            }
+        },
+        "ansi-escapes": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "ansicolors": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+            "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+            "dev": true
+        },
+        "archy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "ast-types": {
+            "version": "0.11.5",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
+            "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
+            "dev": true
+        },
+        "async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+            "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.10"
+            }
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "chardet": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+            "dev": true
+        },
+        "cli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+            "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "glob": "^7.1.1"
+            }
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "clone": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+            "dev": true,
+            "optional": true
+        },
+        "clone-deep": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
+            "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "is-plain-object": "^2.0.1",
+                "kind-of": "^3.2.2",
+                "shallow-clone": "^0.1.2"
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "colors": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+            "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.17.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true,
+                    "optional": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "configstore": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+            "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+            "dev": true,
+            "requires": {
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
+                }
+            }
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "^0.1.4"
+            }
+        },
+        "core-js": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+            "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "crypto-random-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+            "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+            "dev": true
+        },
+        "csslint": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.10.0.tgz",
+            "integrity": "sha1-OmoE51Zcjp0ZvrSXZ8fslug2WAU=",
+            "dev": true,
+            "requires": {
+                "parserlib": "~0.2.2"
+            }
+        },
+        "cycle": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+            "dev": true,
+            "optional": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "data-uri-to-buffer": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+            "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
+            "dev": true
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.2.0",
+            "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+            "dev": true,
+            "requires": {
+                "ms": "0.7.1"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "degenerator": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+            "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+            "dev": true,
+            "requires": {
+                "ast-types": "0.x.x",
+                "escodegen": "1.x.x",
+                "esprima": "3.x.x"
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "diff": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+            "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+            "dev": true
+        },
+        "dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                    "dev": true
+                },
+                "entities": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                    "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+                    "dev": true
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+            "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "dot-prop": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+            "dev": true,
+            "requires": {
+                "is-obj": "^1.0.0"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "email-validator": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+            "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+            "dev": true
+        },
+        "entities": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+            "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+            "dev": true
+        },
+        "es6-promise": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+            "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^4.0.3"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+            "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+            "dev": true
+        },
+        "escodegen": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+            "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+            }
+        },
+        "esprima": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+            "dev": true
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "external-editor": {
+            "version": "2.2.0",
+            "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+            "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+            }
+        },
+        "extract-zip": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+            "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "concat-stream": "1.6.2",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.1",
+                "yauzl": "2.4.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "eyes": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+            "dev": true,
+            "optional": true
+        },
+        "fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "pend": "~1.2.0"
+            }
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                }
+            }
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+            "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "dependencies": {
+                "combined-stream": {
+                    "version": "1.0.6",
+                    "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                    "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "fs-extra": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+            "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "ftp": {
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "1.1.x",
+                "xregexp": "2.0.0"
+            }
+        },
+        "get-uri": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.2.tgz",
+            "integrity": "sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==",
+            "dev": true,
+            "requires": {
+                "data-uri-to-buffer": "1",
+                "debug": "2",
+                "extend": "3",
+                "file-uri-to-path": "1",
+                "ftp": "~0.3.10",
+                "readable-stream": "2"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "requires": {
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
+            }
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "dev": true,
+            "requires": {
+                "is-glob": "^2.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+            "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+            "dev": true
+        },
+        "graphlib": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+            "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.11.1"
+            }
+        },
+        "growl": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+            "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+            "dev": true
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+            "dev": true,
+            "requires": {
+                "ajv": "^5.3.0",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "hasbin": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz",
+            "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
+            "dev": true,
+            "requires": {
+                "async": "~1.5"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                }
+            }
+        },
+        "hasha": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+            "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "is-stream": "^1.0.1",
+                "pinkie-promise": "^2.0.0"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "dev": true
+        },
+        "htmlhint": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-0.10.1.tgz",
+            "integrity": "sha512-Zn+mo0NNXIW7+pWfdIZx49IfmuVI4I1UPjZhXFvc0Rq7fHul//gbVASrnxtiTbOOCNvD4JKVvKkpo4BNDzHi6w==",
+            "dev": true,
+            "requires": {
+                "async": "2.6.1",
+                "colors": "1.3.2",
+                "commander": "2.17.1",
+                "csslint": "^1.0.5",
+                "glob": "7.1.3",
+                "jshint": "^2.9.6",
+                "parse-glob": "3.0.4",
+                "path-parse": "1.0.6",
+                "request": "2.88.0",
+                "snyk": "^1.94.0",
+                "strip-json-comments": "2.0.1",
+                "xml": "1.0.1"
+            },
+            "dependencies": {
+                "csslint": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/csslint/-/csslint-1.0.5.tgz",
+                    "integrity": "sha1-Gcw+2jIhYP0/cjKvHLKjYOiYouk=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "clone": "~2.1.0",
+                        "parserlib": "~1.1.1"
+                    }
+                },
+                "parserlib": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-1.1.1.tgz",
+                    "integrity": "sha1-pkz6ckBiQ0/fw1HJpOwtkrlMBvQ=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "htmlparser2": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+            "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1",
+                "domhandler": "2.3",
+                "domutils": "1.5",
+                "entities": "1.0",
+                "readable-stream": "1.1"
+            }
+        },
+        "http-errors": {
+            "version": "1.6.3",
+            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "dev": true,
+            "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+            }
+        },
+        "http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.1.0",
+                "debug": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+            "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+            }
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^1.0.0"
+            }
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true,
+            "optional": true
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true,
+            "optional": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "jade": {
+            "version": "0.26.3",
+            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+            "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+            "dev": true,
+            "requires": {
+                "commander": "0.6.1",
+                "mkdirp": "0.3.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "0.6.1",
+                    "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.3.0",
+                    "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+                    "dev": true
+                }
+            }
+        },
+        "js-yaml": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                    "dev": true
+                }
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "jshint": {
+            "version": "2.9.6",
+            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.6.tgz",
+            "integrity": "sha512-KO9SIAKTlJQOM4lE64GQUtGBRpTOuvbrRrSZw3AhUxMNG266nX9hK2cKA4SBhXOj0irJGyNyGSLT62HGOVDEOA==",
+            "dev": true,
+            "requires": {
+                "cli": "~1.0.0",
+                "console-browserify": "1.1.x",
+                "exit": "0.1.x",
+                "htmlparser2": "3.8.x",
+                "lodash": "~4.17.10",
+                "minimatch": "~3.0.2",
+                "phantom": "~4.0.1",
+                "phantomjs-prebuilt": "~2.1.7",
+                "shelljs": "0.3.x",
+                "strip-json-comments": "1.0.x",
+                "unicode-5.2.0": "^0.7.5"
+            },
+            "dependencies": {
+                "strip-json-comments": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+                    "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+                    "dev": true
+                }
+            }
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "2.4.0",
+            "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "jszip": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+            "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+            "dev": true,
+            "requires": {
+                "core-js": "~2.3.0",
+                "es6-promise": "~3.0.2",
+                "lie": "~3.1.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.0.6"
+            },
+            "dependencies": {
+                "es6-promise": {
+                    "version": "3.0.2",
+                    "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+                    "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
+            }
+        },
+        "kew": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+            "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+            "dev": true,
+            "optional": true
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5"
+            }
+        },
+        "klaw": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "graceful-fs": "^4.1.9"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "lazy-cache": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+            "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+            "dev": true
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
+            "requires": {
+                "invert-kv": "^1.0.0"
+            }
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "lie": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "dev": true,
+            "requires": {
+                "immediate": "~3.0.5"
+            }
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "dev": true
+        },
+        "lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+            "dev": true
+        },
+        "lodash.assignin": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+            "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+            "dev": true
+        },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
+        },
+        "lodash.set": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+            "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+            "dev": true
+        },
+        "macos-release": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+            "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
+            "dev": true
+        },
+        "make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "mime-db": {
+            "version": "1.36.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.20",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "dev": true,
+            "requires": {
+                "mime-db": "~1.36.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mixin-object": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-in": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+                    "dev": true
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.0",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+            "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "2.3.4",
+            "resolved": "http://registry.npmjs.org/mocha/-/mocha-2.3.4.tgz",
+            "integrity": "sha1-himm+wRPLSJapLgaKuLQAWmesmY=",
+            "dev": true,
+            "requires": {
+                "commander": "2.3.0",
+                "debug": "2.2.0",
+                "diff": "1.4.0",
+                "escape-string-regexp": "1.0.2",
+                "glob": "3.2.3",
+                "growl": "1.8.1",
+                "jade": "0.26.3",
+                "mkdirp": "0.5.0",
+                "supports-color": "1.2.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.3.0",
+                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+                    "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+                    "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "~2.0.0",
+                        "inherits": "2",
+                        "minimatch": "~0.2.11"
+                    }
+                },
+                "minimatch": {
+                    "version": "0.2.14",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "ms": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "nconf": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
+            "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+            "dev": true,
+            "requires": {
+                "async": "^1.4.0",
+                "ini": "^1.3.0",
+                "secure-keys": "^1.0.0",
+                "yargs": "^3.19.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                }
+            }
+        },
+        "needle": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+            "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+            "dev": true,
+            "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+            }
+        },
+        "netmask": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+            "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "opn": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+            "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+            "dev": true,
+            "requires": {
+                "is-wsl": "^1.1.0"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+            }
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true,
+            "requires": {
+                "lcid": "^1.0.0"
+            }
+        },
+        "os-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+            "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+            "dev": true,
+            "requires": {
+                "macos-release": "^1.0.0",
+                "win-release": "^1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "pac-proxy-agent": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
+            "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.2.0",
+                "debug": "^3.1.0",
+                "get-uri": "^2.0.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "pac-resolver": "^3.0.0",
+                "raw-body": "^2.2.0",
+                "socks-proxy-agent": "^3.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "pac-resolver": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
+            "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+            "dev": true,
+            "requires": {
+                "co": "^4.6.0",
+                "degenerator": "^1.0.4",
+                "ip": "^1.1.5",
+                "netmask": "^1.0.6",
+                "thunkify": "^2.1.2"
+            }
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+            "dev": true
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "requires": {
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
+            }
+        },
+        "parserlib": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-0.2.5.tgz",
+            "integrity": "sha1-hZB92GBaoGq7PdKV1QuyuPpN0Rc=",
+            "dev": true
+        },
+        "path": {
+            "version": "0.12.7",
+            "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+            "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+            "dev": true,
+            "requires": {
+                "process": "^0.11.1",
+                "util": "^0.10.3"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true,
+            "optional": true
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "phantom": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz",
+            "integrity": "sha512-Tz82XhtPmwCk1FFPmecy7yRGZG2btpzY2KI9fcoPT7zT9det0CcMyfBFPp1S8DqzsnQnm8ZYEfdy528mwVtksA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "phantomjs-prebuilt": "^2.1.16",
+                "split": "^1.0.1",
+                "winston": "^2.4.0"
+            }
+        },
+        "phantomjs-prebuilt": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+            "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "es6-promise": "^4.0.3",
+                "extract-zip": "^1.6.5",
+                "fs-extra": "^1.0.0",
+                "hasha": "^2.2.0",
+                "kew": "^0.7.0",
+                "progress": "^1.1.8",
+                "request": "^2.81.0",
+                "request-progress": "^2.0.1",
+                "which": "^1.2.10"
+            }
+        },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true,
+            "optional": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "pinkie": "^2.0.0"
+            }
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "prettier": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
+            "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
+            "dev": true
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
+        },
+        "progress": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+            "dev": true,
+            "optional": true
+        },
+        "promise": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "dev": true,
+            "requires": {
+                "asap": "~2.0.3"
+            }
+        },
+        "proxy-agent": {
+            "version": "2.3.1",
+            "resolved": "http://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
+            "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.2.0",
+                "debug": "^3.1.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "lru-cache": "^4.1.2",
+                "pac-proxy-agent": "^2.0.1",
+                "proxy-from-env": "^1.0.0",
+                "socks-proxy-agent": "^3.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "lru-cache": {
+                    "version": "4.1.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+                    "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+            "dev": true
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "psl": {
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "dev": true
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+            "dev": true,
+            "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
+                "unpipe": "1.0.0"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "1.1.14",
+            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "recursive-readdir": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+            "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+            "dev": true,
+            "requires": {
+                "minimatch": "3.0.4"
+            }
+        },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "request-progress": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+            "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "throttleit": "^1.0.0"
+            }
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "^2.1.0"
+            }
+        },
+        "rx-lite": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+            "dev": true
+        },
+        "rx-lite-aggregates": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+            "dev": true,
+            "requires": {
+                "rx-lite": "*"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "secure-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+            "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+            "dev": true
+        },
+        "setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "dev": true
+        },
+        "shallow-clone": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+            "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+            "dev": true,
+            "requires": {
+                "is-extendable": "^0.1.1",
+                "kind-of": "^2.0.1",
+                "lazy-cache": "^0.2.3",
+                "mixin-object": "^2.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "2.0.1",
+                    "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                    "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "shelljs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+            "dev": true
+        },
+        "should": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/should/-/should-7.1.1.tgz",
+            "integrity": "sha1-ZGTEi298Hh8YrASDV4+i3VXCxuA=",
+            "dev": true,
+            "requires": {
+                "should-equal": "0.5.0",
+                "should-format": "0.3.1",
+                "should-type": "0.2.0"
+            }
+        },
+        "should-equal": {
+            "version": "0.5.0",
+            "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
+            "integrity": "sha1-x5fxNfMGf+tp6+zbMGscP+IbPm8=",
+            "dev": true,
+            "requires": {
+                "should-type": "0.2.0"
+            }
+        },
+        "should-format": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.1.tgz",
+            "integrity": "sha1-LLt4JGFnCs5CkrKx7EaNuM+Z4zA=",
+            "dev": true,
+            "requires": {
+                "should-type": "0.2.0"
+            }
+        },
+        "should-type": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
+            "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
+            "dev": true
+        },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "smart-buffer": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+            "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
+            "dev": true
+        },
+        "snyk": {
+            "version": "1.100.1",
+            "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.100.1.tgz",
+            "integrity": "sha512-7/BA+MZSNLwWphz1nt/IyFxncaLecytpTuzN2ef5MWskj6ATWaBnz4kjQ9v27Zpr53hifP2JeCeqaze1a0DGXw==",
+            "dev": true,
+            "requires": {
+                "abbrev": "^1.1.1",
+                "ansi-escapes": "^3.1.0",
+                "chalk": "^2.4.1",
+                "configstore": "^3.1.2",
+                "debug": "^3.1.0",
+                "hasbin": "^1.2.3",
+                "inquirer": "^3.0.0",
+                "lodash": "^4.17.5",
+                "needle": "^2.2.4",
+                "opn": "^5.2.0",
+                "os-name": "^2.0.1",
+                "proxy-agent": "^2.0.0",
+                "proxy-from-env": "^1.0.0",
+                "recursive-readdir": "^2.2.2",
+                "semver": "^5.5.0",
+                "snyk-config": "2.2.0",
+                "snyk-docker-plugin": "1.11.0",
+                "snyk-go-plugin": "1.5.2",
+                "snyk-gradle-plugin": "2.0.1",
+                "snyk-module": "1.8.2",
+                "snyk-mvn-plugin": "2.0.0",
+                "snyk-nodejs-lockfile-parser": "1.5.1",
+                "snyk-nuget-plugin": "1.6.5",
+                "snyk-php-plugin": "1.5.1",
+                "snyk-policy": "1.12.0",
+                "snyk-python-plugin": "1.8.1",
+                "snyk-resolve": "1.0.1",
+                "snyk-resolve-deps": "4.0.0",
+                "snyk-sbt-plugin": "2.0.0",
+                "snyk-tree": "^1.0.0",
+                "snyk-try-require": "1.3.1",
+                "source-map-support": "^0.5.9",
+                "tempfile": "^2.0.0",
+                "then-fs": "^2.0.0",
+                "undefsafe": "^2.0.0",
+                "uuid": "^3.2.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-config": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-2.2.0.tgz",
+            "integrity": "sha512-mq0wbP/AgjcmRq5i5jg2akVVV3iSYUPTowZwKn7DChRLDL8ySOzWAwan+ImXiyNbrWo87FNI/15O6MpOnTxOIg==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "lodash": "^4.17.5",
+                "nconf": "^0.10.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-docker-plugin": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.11.0.tgz",
+            "integrity": "sha512-rJrSj4FfGtaFGNybWTb0bULEqoQEeZfZBpGoDumiXsGqoSWf61Tr1V/Ck9NGcmHWNEVsLZLcE9CXp6Y6Kbo8qA==",
+            "dev": true,
+            "requires": {
+                "debug": "^3",
+                "tslib": "^1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-go-plugin": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.5.2.tgz",
+            "integrity": "sha512-XWajcSh6Ld+I+WdcyU3DGDuE2ydThQd8ORkESy0nQ2LwekygLYVYN66OBy0uxpqYfd4qoqeg+J8lb4oGzCmyGA==",
+            "dev": true,
+            "requires": {
+                "graphlib": "^2.1.1",
+                "tmp": "0.0.33",
+                "toml": "^2.3.2"
+            }
+        },
+        "snyk-gradle-plugin": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.0.1.tgz",
+            "integrity": "sha512-dL9MRlwmDP4OmOk4b61pMqvbu8gG+HVCBTryBEU+vkvjloX0lslKvA5NTUPAM2M8SShnOic54cSegGQChBhYHw==",
+            "dev": true,
+            "requires": {
+                "clone-deep": "^0.3.0"
+            }
+        },
+        "snyk-module": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-1.8.2.tgz",
+            "integrity": "sha512-XqhdbZ/CUuJ5gSaYdYfapLqx9qm2Mp6nyRMBCLXe9tJSiohOJsc9fQuUDbdOiRCqpA4BD6WLl+qlwOJmJoszBg==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "hosted-git-info": "^2.1.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-mvn-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.0.0.tgz",
+            "integrity": "sha512-9jAhZhv+7YcqtoQYCYlgMoxK+dWBKlk+wkX27Ebg3vNddNop9q5jZitRXTjsXwfSUZHRt+Ptw1f8vei9kjzZVg==",
+            "dev": true
+        },
+        "snyk-nodejs-lockfile-parser": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.5.1.tgz",
+            "integrity": "sha512-rfFcW+ZrOEH3NxufUCpMBpNLSb4BPOxLbAM6MoRqfYH5DhSdTHsecwRDf1gU6XzQok/9Koav+1qtP8+welJC2A==",
+            "dev": true,
+            "requires": {
+                "@yarnpkg/lockfile": "^1.0.2",
+                "lodash": "4.17.10",
+                "path": "0.12.7",
+                "source-map-support": "^0.5.7"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-nuget-plugin": {
+            "version": "1.6.5",
+            "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.6.5.tgz",
+            "integrity": "sha512-3qIndzkxCxiaGvAwMkqChbChGdwhNePPyfi0WjhC/nJGwecqU3Fb/NeTW7lgyT+xoq/dFnzW0DgBJ4+AyNA2gA==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "jszip": "^3.1.5",
+                "lodash": "^4.17.10",
+                "xml2js": "^0.4.17"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-php-plugin": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.5.1.tgz",
+            "integrity": "sha512-g5QSHBsRJ2O4cNxKC4zlWwnQYiSgQ77Y6QgGmo3ihPX3VLZrc1amaZIpPsNe1jwXirnGj2rvR5Xw+jDjbzvHFw==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "lodash": "^4.17.5",
+                "path": "0.12.7"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-policy": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.12.0.tgz",
+            "integrity": "sha512-CEioNnDzccHyid7UIVl3bJ1dnG4co4ofI+KxuC1mo0IUXy64gxnBTeVoZF5gVLWbAyxGxSeW8f0+8GmWMHVb7w==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "email-validator": "^2.0.3",
+                "js-yaml": "^3.5.3",
+                "lodash.clonedeep": "^4.3.1",
+                "semver": "^5.5.0",
+                "snyk-module": "^1.8.2",
+                "snyk-resolve": "^1.0.1",
+                "snyk-try-require": "^1.1.1",
+                "then-fs": "^2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-python-plugin": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.8.1.tgz",
+            "integrity": "sha512-DsUBkQZiPlXGkwzhxxEo2Tvfq6XhygWQThWM0yRBythi9M5n8UimZEwdkBHPj7xKC1clsB8boM3+sT/E1x6XGA==",
+            "dev": true,
+            "requires": {
+                "tmp": "0.0.33"
+            }
+        },
+        "snyk-resolve": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/snyk-resolve/-/snyk-resolve-1.0.1.tgz",
+            "integrity": "sha512-7+i+LLhtBo1Pkth01xv+RYJU8a67zmJ8WFFPvSxyCjdlKIcsps4hPQFebhz+0gC5rMemlaeIV6cqwqUf9PEDpw==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "then-fs": "^2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-resolve-deps": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.0.0.tgz",
+            "integrity": "sha512-EWqkRLAFUr09ZdAz9kJGXtxPlYsa+ZXYYF6KO0X6lZsPdFN3bUcT/ryDzaEemB6gJAMDvoWORWpmbaqQM7c7yw==",
+            "dev": true,
+            "requires": {
+                "ansicolors": "^0.3.2",
+                "debug": "^3.2.5",
+                "lodash.assign": "^4.2.0",
+                "lodash.assignin": "^4.2.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.get": "^4.4.2",
+                "lodash.set": "^4.3.2",
+                "lru-cache": "^4.0.0",
+                "semver": "^5.5.1",
+                "snyk-module": "^1.6.0",
+                "snyk-resolve": "^1.0.0",
+                "snyk-tree": "^1.0.0",
+                "snyk-try-require": "^1.1.1",
+                "then-fs": "^2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "lru-cache": {
+                    "version": "4.1.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+                    "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "snyk-sbt-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.0.0.tgz",
+            "integrity": "sha512-bOUqsQ1Lysnwfnvf4QQIBfC0M0ZVuhlshTKd7pNwgAJ41YEPJNrPEpzOePl/HfKtwilEEwHh5YHvjYGegEKx0A==",
+            "dev": true
+        },
+        "snyk-tree": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/snyk-tree/-/snyk-tree-1.0.0.tgz",
+            "integrity": "sha1-D7cxdtvzLngvGRAClBYESPkRHMg=",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0"
+            }
+        },
+        "snyk-try-require": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/snyk-try-require/-/snyk-try-require-1.3.1.tgz",
+            "integrity": "sha1-bgJvkuZK9/zM6h7lPVJIQeQYohI=",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "lodash.clonedeep": "^4.3.0",
+                "lru-cache": "^4.0.0",
+                "then-fs": "^2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "lru-cache": {
+                    "version": "4.1.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+                    "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "socks": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+            "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+            "dev": true,
+            "requires": {
+                "ip": "^1.1.4",
+                "smart-buffer": "^1.0.13"
+            }
+        },
+        "socks-proxy-agent": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+            "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.1.0",
+                "socks": "^1.1.10"
+            }
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "through": "2"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true,
+            "optional": true
+        },
+        "statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            }
+        },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^3.0.0"
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+            "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+            "dev": true
+        },
+        "temp-dir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+            "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+            "dev": true
+        },
+        "tempfile": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+            "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+            "dev": true,
+            "requires": {
+                "temp-dir": "^1.0.0",
+                "uuid": "^3.0.1"
+            }
+        },
+        "then-fs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
+            "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
+            "dev": true,
+            "requires": {
+                "promise": ">=3.2 <8"
+            }
+        },
+        "throttleit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+            "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+            "dev": true,
+            "optional": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "thunkify": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+            "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
+            "dev": true
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "toml": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+            "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
+            "dev": true
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            }
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true,
+            "optional": true
+        },
+        "undefsafe": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
+            "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0"
+            }
+        },
+        "unicode-5.2.0": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/unicode-5.2.0/-/unicode-5.2.0-0.7.5.tgz",
+            "integrity": "sha512-KVGLW1Bri30x00yv4HNM8kBxoqFXr0Sbo55735nvrlsx4PYBZol3UtoWgO492fSwmsetzPEZzy73rbU8OGXJcA==",
+            "dev": true
+        },
+        "unique-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+            "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+            "dev": true,
+            "requires": {
+                "crypto-random-string": "^1.0.0"
+            }
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "util": {
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "win-release": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+            "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+            "dev": true,
+            "requires": {
+                "semver": "^5.0.1"
+            }
+        },
+        "window-size": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+            "dev": true
+        },
+        "winston": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+            "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "async": "~1.0.0",
+                "colors": "1.0.x",
+                "cycle": "1.0.x",
+                "eyes": "0.1.x",
+                "isstream": "0.1.x",
+                "stack-trace": "0.0.x"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.0.0",
+                    "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+                    "dev": true,
+                    "optional": true
+                },
+                "colors": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write-file-atomic": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
+                }
+            }
+        },
+        "xdg-basedir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+            "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+            "dev": true
+        },
+        "xml": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+            "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dev": true,
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "dev": true
+        },
+        "xregexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
+            "dev": true
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "3.32.0",
+            "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^2.0.1",
+                "cliui": "^3.0.3",
+                "decamelize": "^1.1.1",
+                "os-locale": "^1.4.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.1.4",
+                "y18n": "^3.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "yauzl": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+            "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "fd-slicer": "~1.0.1"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
     "dependencies": {},
     "devDependencies": {
         "csslint": "~0.10.0",
-        "htmlhint": "~0.9.13",
-        "jshint": "~2.8.0",
+        "htmlhint": "^0.10.1",
+        "jshint": "^2.9.6",
         "mocha": "~2.3.3",
+        "prettier": "~1.14.3",
         "should": "~7.1.0"
     }
 }


### PR DESCRIPTION
Algumas versoes dos pacotes do npm estavam com grande risco de seguranca.
Esta atualizacao melhora o nivel de seguranca do projeto.

Alem disto, o prittier ajuda a manter o codigo formatado.