### PR TITLE
Remove evendo passado - WordCamp São Paulo 2018

### DIFF
--- a/javascripts/data/events.json
+++ b/javascripts/data/events.json
@@ -61,18 +61,6 @@
         "link": "https://phpconference.com.br/"
       },
      {
-      "titulo": "WordCamp São Paulo 2018",
-      "dataInicio": "2018-10-13",
-      "dataFim": "2018-10-13",
-      "local": "Universidade Nove de Julho (Uninove)",
-      "endereco": "Rua Vagueiro, 235/249 - Liberdade, São Paulo - SP, Brasil",
-      "localizacao": {
-        "latitude": -23.564216,
-        "longitude": -46.638025
-      },
-      "link": "https://2018.saopaulo.wordcamp.org/"
-     },
-     {
         "titulo": "Roadsec São Paulo 2018",
         "dataInicio": "2018-11-10",
         "dataFim": "2018-11-10",


### PR DESCRIPTION
Remove evento passado: 
- WordCamp São Paulo 2018
- Data: 13 de outubro de 2018