### PR TITLE
Correção em data de evento

### DIFF
--- a/javascripts/data/events.json
+++ b/javascripts/data/events.json
@@ -2,8 +2,8 @@
   "events": [
     { 
       "titulo": "Locaweb PHP Community Summit", 
-      "dataInicio": "2019-07-26", 
-      "dataFim": "2019-06-27", 
+      "dataInicio": "2019-09-26", 
+      "dataFim": "2019-09-27", 
       "local": "Developer E-Commerce HUB", 
       "endereco": "Rua Oscar Freire, 2379 - Pinheiros, São Paulo - SP, 05409-12",
       "localizacao": { 


### PR DESCRIPTION
O evento estava cadastrado do dia 26/07 até 27/06. A data correta é do dia 26/09 até 27/09, segundo o site do <a href="https://www.php.locaweb.com.br/">Locaweb PHP Community Summit 2019</a>.